### PR TITLE
Non-element handling

### DIFF
--- a/src/baustein.js
+++ b/src/baustein.js
@@ -467,19 +467,26 @@ export function handleEvent(event, componentsChain) {
 
 /**
  * Parses the given element or the root element and creates Component instances.
- * @param {HTMLElement} [root]
+ * @param {HTMLElement} [node]
  * @returns {Component[]}
  */
-export function parse(root) {
+export function parse(node) {
+
+    if (arguments.length === 0) {
+        node = doc.body;
+    }
+    else if (!isElement(node)) {
+        throw new Error('node must be an HTMLElement');
+    }
 
     // allow DOM element or nothing
-    root = isElement(root) ? root : doc.body;
+    node = isElement(node) ? node : doc.body;
 
-    var els = slice.call(root.querySelectorAll('[is]'));
+    var els = slice.call(node.querySelectorAll('[is]'));
     var component;
 
     // add the root element to the front
-    els.unshift(root);
+    els.unshift(node);
 
     return els.reduce(function (result, el) {
 
@@ -622,9 +629,11 @@ export function unbindEvents() {
  * @param node
  */
 function nodeInserted(node) {
-    var components = parse(node);
-    invoke(components, 'onInsert');
-    invoke(components, 'emit', 'inserted');
+    if (isElement(node)) {
+        var components = parse(node);
+        invoke(components, 'onInsert');
+        invoke(components, 'emit', 'inserted');
+    }
 }
 
 /**
@@ -633,7 +642,9 @@ function nodeInserted(node) {
  * @param node
  */
 function nodeRemoved(node) {
-    invoke(parse(node), 'onRemove');
+    if (isElement(node)) {
+        invoke(parse(node), 'onRemove');
+    }
 }
 
 /**

--- a/test/spec/baustein.js
+++ b/test/spec/baustein.js
@@ -1217,6 +1217,16 @@ define(['../../dist/baustein.amd.js'], function (baustein) {
 
         });
 
+        describe('baustein.parse()', function () {
+
+            it('should throw an error if the passed argument is not an element', function () {
+                expect(baustein.parse).withArgs(null).to.throwException();
+                expect(baustein.parse).withArgs(document.createTextNode('hello')).to.throwException();
+                expect(baustein.parse).withArgs({}).to.throwException();
+            });
+
+        });
+
     });
 
 });


### PR DESCRIPTION
@djmc @iprignano 

Found a bug in the mutation observer stuff.

If a text node is inserted somewhere on the page then `nodeInserted` is called which calls `parse` to get all the components in the `node`'s subtree. However `parse` says if the passed argument is not an element then use `<body>`. So 2 changes here to fix this:

* `nodeInserted` and `nodeRemoved` both check that `node` is an element
* `parse` now uses `<body>` **ONLY** if no argument was passed e.g. `baustein.parse()`. If an argument is given and it is not an element then an error is thrown.
* Added a text for the previous point