### PR TITLE
bind events before calling nodeInserted on body

### DIFF
--- a/src/baustein.js
+++ b/src/baustein.js
@@ -733,11 +733,12 @@ export function init(options) {
         domWrapper = options.domWrapper;
     }
 
+    bindEvents();
+
     // by calling `nodeInserted` not only will all the components present at page load be parsed
     // but `onInsert` will be called and the "inserted" event will be emitted on each
     nodeInserted(doc.body);
 
-    bindEvents();
 }
 
 /**


### PR DESCRIPTION
Events need to be bound before the initial parse of the body as otherwise if any component adds new components to the DOM during the initial parse they are not picked up by the mutation events.

@djmc @iprignano @Stereobit 