### PR TITLE
RFC: Updates to the way components render

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -84,6 +84,10 @@ module.exports = function (grunt) {
                                 type: 'text-summary',
                                 subdir: '.',
                                 file: 'text-summary.txt'
+                            },
+                            {
+                                type: 'html',
+                                dir: 'coverage'
                             }
                         ]
                     }


### PR DESCRIPTION
## Overview
* Add `getRenderContext` method that is used to get the context for rendering a template
* Removes the `destroy` event as we can't guarantee it will be emitted
* Removes the `beforeDestroy` method has we can't guarantee it will be called
* Removes the support the `template` to be a string as it complicates `render` and there really isn't much use case for it.

## Example
Here is a simple component.
```js
var Thing = baustein.register('my-thing', {

    // assume this is the compiled template function
    template: myThingTemplate,

    setupEvents: function () {
        add('click', 'button', this.increment);
    },

    increment: function () {
        this.options.count += 1;
        this.render();
    },

    getRenderContext: function () {
        return {
            count: this.option.count;
        };
    }
});
```

And here is it's template (imported above as `myThingTemplate`):
```jinja
<div class="my-thing" is="my-thing">
    The count is <span class="count">{{ count }}</span>
    <button>Click me!</button>
</div>
```

The first thing to note is that with these changes the DOM structure of this component after being created will be:
```html
<div class="my-thing" is="my-thing" data-component-id="1">
    The count is <span class="count">{{ count }}</span>
    <button>Click me!</button>
</div>
```

**Breaking change: The root node of the template is assumed to be the root node of the component**
In current master this example would actually cause an infinitely recursive loop as each time the component renders itself it would insert the result of the template into itself using `innerHTML`, which would result in a new `my-thing` component being created, and so on, and so on. Although this is a breaking change I think it makes sense, you want your template to define the whole DOM structure for a component, including the root node.

**getRenderContent()**
The second thing to note is that this component implemented `getRenderContext` and returned only the context needed to render the template. For backwards compatibility the default implementation of this method is to return `this`. I think moving forward we should drop this behaviour and make the default implementation return an empty object, as then we could quite easily implement a deep equals check on the previous context and the new context and not re-render if it hasn't changed.

@djmc @iprignano @skyllo @csharpd @mattvagni