### PR TITLE
Fix render() in IE

### DIFF
--- a/src/baustein.js
+++ b/src/baustein.js
@@ -958,7 +958,7 @@ Component.prototype = {
             throw new Error('A component template must produce a single DOM node.');
         }
 
-        newElement = tmpEl.firstElementChild;
+        newElement = tmpEl.removeChild(tmpEl.firstElementChild);
         tmpEl.innerHTML = '';
 
         if (newElement.tagName !== this.el.tagName) {


### PR DESCRIPTION
@djmc @iprignano 

Quick example showing the problem:

```js
// setup
var tmp = document.createElement('div');
tmp.innerHTML = '<div><p>hello world</p></div>';

// old baustein code
var el = tmp.firstElementChild;
tmp.innerHTML = '';

// In Chrome, FF, Safari etc.. `el` is still the <div> with the <p> inside it
// In IE `el` is still the <div> but it's innerHTML is now empty

// new baustein code
var el = tmp.removeChild(tmp.firstElementChild);
tmp.innerHTML = '';

// by removing the element from the temp parent we make sure 
// we have the only the reference to it
```