### PR TITLE
Have onOptionsChange be called with the previous component options.

### DIFF
--- a/src/baustein.js
+++ b/src/baustein.js
@@ -1159,13 +1159,14 @@ Component[prototype] = {
 
     /**
      * Updates this components options. If calling this method results in the options changing then
-     * `onOptionsChanged` will be called.
+     * `onOptionsChanged` will be called with the previous options.
      * @param options
      */
     updateOptions: function (options) {
+        var optionsClone = clone(this.options);
 
         if (updateObject(this.options, options)) {
-            this.onOptionsChange();
+            this.onOptionsChange(optionsClone);
         }
 
         return this;

--- a/test/spec/baustein.js
+++ b/test/spec/baustein.js
@@ -1591,6 +1591,7 @@ define(['../../dist/baustein.amd.js'], function (baustein) {
                     var c = new C(initial);
                     c.updateOptions(update);
                     expect(spy.callCount).to.equal(1);
+                    expect(spy.getCall(0).args[0]).to.eql(initial);
                 });
 
             });


### PR DESCRIPTION
Currently when you call `someComponent.updateOptions({ ... })` you don't really know what changed in your component's `onOptionsChange()` hook.

This is mildly annoying since it means that if you want to know what changed you have to something terrible like this to save a reference to the previous component options:

```javascript
baustein.register('foo', {
    
    init: function () {
        this.oldOptions = _.clone(this.options);
    },

    onOptionsChange: function () {
        // Do something here comparing
        // this.oldOptions and this.options

        this.oldOptions = _.clone(this.options);
    }

});
```

What this PR does is makes sure that 'onOptionsChange()' hook is called with the previous options so the above isn't necessary.

@djmc @jonbretman @skyllo @iprignano