### PR TITLE
ensureEventHasMethod shouldn't rewrite existing properties/methods

### DIFF
--- a/src/baustein.js
+++ b/src/baustein.js
@@ -481,18 +481,15 @@ export function isComponent(component) {
     return component instanceof Component;
 }
 
-function ensureEventHasMethod(event, method, property) {
-    var originalMethod = event[method];
-
-    if (typeof event[property] === 'undefined') {
-        event[property] = false;
+function ensureEventHasMethod(event, methodName, propertyName) {
+    if (propertyName in event || methodName in event) {
+        return; // don't override existing methods
     }
 
-    event[method] = function () {
-        event[property] = true;
-        if (originalMethod) {
-            return originalMethod[apply](event, arguments);
-        }
+    event[propertyName] = false;
+
+    event[methodName] = function () {
+        event[propertyName] = true;
     };
 }
 


### PR DESCRIPTION
ensureEventHasMethod overrides the original properties and methods of a couple of features (preventDefault and stopPropagation), however this isn't allowed in strict mode, which is preventing WebPack+Babel from building it properly.

@jonbretman @mattvagni 