### PR TITLE
Change the order of returned components from parse - now bottom up instead of top down

### DIFF
--- a/src/baustein.js
+++ b/src/baustein.js
@@ -628,7 +628,7 @@ function pushEventJobsForGlobalHandlers(event) {
 /**
  * Parses the given element or the root element and creates Component instances.
  * @param {HTMLElement} [node] If not provided then the <body> will be parsed.
- * @param {boolean} [ignoreRootNode=false] If not provided then the <body> will be parsed.
+ * @param {boolean} [ignoreRootNode=false] If `true` then the root not will not be parsed or returned.
  * @returns {Component[]}
  */
 export function parse(node, ignoreRootNode) {
@@ -640,25 +640,27 @@ export function parse(node, ignoreRootNode) {
         throw Error('node must be an HTMLElement');
     }
 
-    var els = slice[call](node.querySelectorAll('[is]'));
-    var component;
+    var result = [];
 
-    // if it's not being ignored add the root element to the front
-    if (ignoreRootNode !== true) {
-        els.unshift(node);
+    for (var i = 0; i < node.childNodes.length; i++) {
+        if (isElement(node.childNodes[i])) {
+            result = result.concat(parse(node.childNodes[i], false));
+        }
     }
 
-    return els.reduce(function (result, el) {
-
-        component = fromElement(el);
-
-        if (component && component[stateKey] !== STATE_DESTROYED) {
-            result[push](component);
-        }
-
+    // If `ignoreRootNode` is true then we can just return the
+    // result of calling `parse` on all children.
+    if (ignoreRootNode === true) {
         return result;
+    }
 
-    }, []);
+    var component = fromElement(node);
+
+    if (component && component[stateKey] !== STATE_DESTROYED) {
+        result[push](component);
+    }
+
+    return result;
 }
 
 /**

--- a/test/spec/baustein.js
+++ b/test/spec/baustein.js
@@ -324,15 +324,12 @@ define(['../../dist/baustein.amd.js'], function (baustein) {
 
                     expect(parent.destroy.callCount).to.equal(1);
                     expect(child.destroy.callCount).to.equal(1);
-
-                    // We expect this to be called twice as it will first be called as a result
-                    // of `parent` calling destroy on all it's children and then again as a result
-                    // of `child` calling destroy on all it's children.
-                    expect(grandchild.destroy.callCount).to.equal(2);
+                    expect(grandchild.destroy.callCount).to.equal(1);
 
                     // check destroy() was called on each component in the expected order
                     expect(parent.destroy.calledBefore(child.destroy)).to.equal(true);
-                    expect(child.destroy.calledBefore(grandchild.destroy)).to.equal(true);
+                    expect(parent.destroy.calledBefore(grandchild.destroy)).to.equal(true);
+                    expect(grandchild.destroy.calledBefore(child.destroy)).to.equal(true);
                 });
 
                 it('during the emitting of the "destroy" event isDestroying() is true', function () {
@@ -1383,8 +1380,8 @@ define(['../../dist/baustein.amd.js'], function (baustein) {
                     // setTimeout, 100ms should be more than enough.
                     setTimeout(function () {
                         expect(spy.callCount).to.equal(2);
-                        expect(spy.getCall(0).thisValue).to.equal(c1);
-                        expect(spy.getCall(1).thisValue).to.equal(c2);
+                        expect(spy.getCall(0).thisValue).to.equal(c2);
+                        expect(spy.getCall(1).thisValue).to.equal(c1);
                         done();
                     }, 100);
                 });
@@ -1419,8 +1416,8 @@ define(['../../dist/baustein.amd.js'], function (baustein) {
                     // setTimeout, 100ms should be more than enough.
                     setTimeout(function () {
                         expect(spy.callCount).to.equal(2);
-                        expect(spy.getCall(0).thisValue).to.equal(c1);
-                        expect(spy.getCall(1).thisValue).to.equal(c2);
+                        expect(spy.getCall(0).thisValue).to.equal(c2);
+                        expect(spy.getCall(1).thisValue).to.equal(c1);
                         done();
                     }, 100);
                 });
@@ -1828,7 +1825,7 @@ define(['../../dist/baustein.amd.js'], function (baustein) {
                 var c2 = new C();
                 c2.appendTo(c1);
 
-                expect(baustein.parse(c1.el)).to.eql([c1, c2]);
+                expect(baustein.parse(c1.el)).to.eql([c2, c1]);
                 expect(baustein.parse(c1.el, true)).to.eql([c2]);
             });
 


### PR DESCRIPTION
@djmc @csharpd @iprignano @skyllo 

This is something I have been thinking of doing for a while, it's quite a small change but it means that methods like `init`, `onInsert`, and `onRemove` are called on children before parents (bottom up).