### PR TITLE
Support component options being parsed as base64 encoded JSON

### DIFF
--- a/src/baustein.js
+++ b/src/baustein.js
@@ -367,10 +367,18 @@ function parseAttributes(el) {
         name = toCamelCase(el[attributes][i].name);
         value = el[attributes][i].value;
 
+        // Try parsing as JSON
         try {
             value = JSON.parse(value);
         }
         catch (e) {
+            // Try decoding as base64 and then parsing as JSON
+            try {
+                value = JSON.parse(win.atob(value));
+            }
+            catch (er) {
+                // oh well.
+            }
         }
 
         result[name] = value;

--- a/test/spec/baustein.js
+++ b/test/spec/baustein.js
@@ -125,13 +125,17 @@ define(['../../dist/baustein.amd.js'], function (baustein) {
 
                 var el = document.createElement('div');
                 el.setAttribute('foo', 'foo');
-                el.setAttribute('bar', JSON.stringify({key: 'value'}));
+                el.setAttribute('bar-json', JSON.stringify({key: 'valué "foo"'}));
+                el.setAttribute('bar-base64', window.btoa(JSON.stringify({key: 'valué "foo"'})));
                 el.setAttribute('baz-bob', 5);
 
                 expect(new Component(el).options).to.eql({
                     foo: 'foo',
-                    bar: {
-                        key: 'value'
+                    barJson: {
+                        key: 'valué "foo"'
+                    },
+                    barBase64: {
+                        key: 'valué "foo"'
                     },
                     bazBob: 5
                 });


### PR DESCRIPTION
@iprignano @djmc @skyllo 

Passing JSON strings to components is a bit awkward as you have to escape all the values but not the whole JSON string.

This allow options to be passed as a base64 encoded JSON:

```html
<div is="my-thing" some-data="eyJrZXkiOiJ2YWx1ZSJ9"></div>
``` 

```js
baustein.register('my-thing', {

    init() {
        console.log(this.options.someData);
        // {key: 'value'}
    }

});
```