### PR TITLE
Faster parseAttributes

### DIFF
--- a/src/baustein.js
+++ b/src/baustein.js
@@ -363,29 +363,35 @@ function parseAttributes(el) {
     var value;
 
     for (var i = 0; i < el[attributes][lengthKey]; i++) {
-
         name = toCamelCase(el[attributes][i].name);
-        value = el[attributes][i].value;
-
-        // Try parsing as JSON
-        try {
-            value = JSON.parse(value);
-        }
-        catch (e) {
-            // Try decoding as base64 and then parsing as JSON
-            try {
-                value = JSON.parse(win.atob(value));
-            }
-            catch (er) {
-                // oh well.
-            }
-        }
+        value = tryJSON(el[attributes][i].value);
 
         result[name] = value;
-
     }
 
     return result;
+}
+
+/**
+ * Try to JSON decode a string. Possibly Base64 encoded.
+ *
+ * Will try to decode this string to an object. Will return the original string
+ * if JSON.parse fails.
+ * @param {String} value
+ * @returns {*}
+ */
+function tryJSON(value) {
+    if (value.endsWith("==")) {
+        try {
+            return JSON.parse(win.atob(value));
+        } catch (er) {}
+    }
+
+    try {
+        return JSON.parse(value);
+    } catch (er) {}
+
+    return value;
 }
 
 /**

--- a/src/baustein.js
+++ b/src/baustein.js
@@ -104,6 +104,8 @@ var allEvents = {
     drop: false
 };
 
+var b64regex = /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}=))?$/;
+
 /**
  * Returns the 'inner' type of `obj`.
  * @param {*} obj
@@ -381,17 +383,18 @@ function parseAttributes(el) {
  * @returns {*}
  */
 function tryJSON(value) {
-    if (value.endsWith("==")) {
+    if (b64regex.test(value)) {
         try {
             return JSON.parse(win.atob(value));
-        } catch (er) {}
+        } catch (er) {
+        }
     }
 
     try {
         return JSON.parse(value);
-    } catch (er) {}
-
-    return value;
+    } catch (er) {
+        return value;
+    }
 }
 
 /**


### PR DESCRIPTION
This improves parseAttributes in 2 ways.

1. try/catch will cause V8 not to optimise functions containing it.  So shift the exception handling out into a helper function so most of the loop is still optimised.
2. Don't attempt to Base64 decode things which can't possibly be Base64 encoded.

My (very rough) benchmarks suggest this to be 20-30% faster at setting up components. Previously something like 75% of component startup time was simply in parseAttributes.